### PR TITLE
push images to images table

### DIFF
--- a/src/bulmapsaur/main/app.py
+++ b/src/bulmapsaur/main/app.py
@@ -17,7 +17,7 @@ class ImageRequestHandler(tornado.web.RequestHandler):
             idAssay = imageInfo.get('idAssay')
             idExperiment = imageInfo.get('idExperiment')
             imageB64 = imageInfo.get('base64')
-            app_log.info("Image with idTest %s and idPlant %s received",idAssay,idExperiment)
+            app_log.info("Image with idAssay %s and idExperiment %s received",idAssay,idExperiment)
             #En algun momento va a correr
             IOLoop.current().spawn_callback(imageService.processImage, idAssay,idExperiment, imageB64)
             self.write("Ok")

--- a/src/bulmapsaur/main/app.py
+++ b/src/bulmapsaur/main/app.py
@@ -14,12 +14,12 @@ class ImageRequestHandler(tornado.web.RequestHandler):
     async def post(self): 
             data = self.request.body
             imageInfo = json.loads(data)
-            idTest = imageInfo.get('idTest')
-            idPlant = imageInfo.get('idPlant')
+            idAssay = imageInfo.get('idAssay')
+            idExperiment = imageInfo.get('idExperiment')
             imageB64 = imageInfo.get('base64')
-            app_log.info("Image with idTest %s and idPlant %s received",idTest,idPlant)
+            app_log.info("Image with idTest %s and idPlant %s received",idAssay,idExperiment)
             #En algun momento va a correr
-            IOLoop.current().spawn_callback(imageService.processImage, idTest,idPlant, imageB64)
+            IOLoop.current().spawn_callback(imageService.processImage, idAssay,idExperiment, imageB64)
             self.write("Ok")
             self.finish()
 

--- a/src/bulmapsaur/main/cassandra_connector.py
+++ b/src/bulmapsaur/main/cassandra_connector.py
@@ -1,12 +1,12 @@
 from cassandra.cluster import Cluster
 from datetime import datetime
 
-def insert(idTest, idPlant, measures, image):
+def insert(idAssay, idExperiment, measures, image):
     cluster = Cluster(['104.197.222.72'])
     session = cluster.connect('nano',wait_for_all_pools=True)
     session.execute('USE nano')
     timeNow = datetime.now()
-    id_assay = int(idTest)
-    id_experiment = int(idPlant)
+    id_assay = int(idAssay)
+    id_experiment = int(idExperiment)
     session.execute('insert into measures(id_assay,id_experiment,time,measures) values(%s,%s,%s,%s)', (id_assay,id_experiment,timeNow,str(measures)))
     session.execute_async('insert into images(id_assay,id_experiment,time,image) values(%s,%s,%s,%s)',(id_assay, id_experiment, timeNow, str(image)))

--- a/src/bulmapsaur/main/cassandra_connector.py
+++ b/src/bulmapsaur/main/cassandra_connector.py
@@ -8,10 +8,5 @@ def insert(idTest, idPlant, measures, image):
     timeNow = datetime.now()
     id_assay = int(idTest)
     id_experiment = int(idPlant)
-    try:
-        session.execute('insert into measures(id_assay,id_experiment,time,measures) values(%s,%s,%s,%s)', (id_assay,id_experiment,timeNow,str(measures)))
-    except:
-        print("could not insert measures")
-    else:
-        session.execute_async('insert into images(id_assay,id_experiment,time,image) values(%s,%s,%s,%s)',(id_assay, id_experiment, timeNow, str(image)))
-
+    session.execute('insert into measures(id_assay,id_experiment,time,measures) values(%s,%s,%s,%s)', (id_assay,id_experiment,timeNow,str(measures)))
+    session.execute_async('insert into images(id_assay,id_experiment,time,image) values(%s,%s,%s,%s)',(id_assay, id_experiment, timeNow, str(image)))

--- a/src/bulmapsaur/main/cassandra_connector.py
+++ b/src/bulmapsaur/main/cassandra_connector.py
@@ -13,5 +13,5 @@ def insert(idTest, idPlant, measures, image):
     except:
         print("could not insert measures")
     else:
-        session.execute('insert into images(id_assay,id_experiment,time,image) values(%s,%s,%s,%s)',(id_assay, id_experiment, timeNow, str(image)))
+        session.execute_async('insert into images(id_assay,id_experiment,time,image) values(%s,%s,%s,%s)',(id_assay, id_experiment, timeNow, str(image)))
 

--- a/src/bulmapsaur/main/cassandra_connector.py
+++ b/src/bulmapsaur/main/cassandra_connector.py
@@ -1,9 +1,17 @@
 from cassandra.cluster import Cluster
+from datetime import datetime
 
 def insert(idTest, idPlant, measures, image):
     cluster = Cluster(['104.197.222.72'])
     session = cluster.connect('nano',wait_for_all_pools=True)
     session.execute('USE nano')
-    id_test = int(idTest)
-    id_plant = int(idPlant)
-    session.execute('insert into measures(id_test,id_plant,time,measures,image) values(%s,%s,dateOf(now()),%s,%s)', (id_test,id_plant,str(measures),str(image)))
+    timeNow = datetime.now()
+    id_assay = int(idTest)
+    id_experiment = int(idPlant)
+    try:
+        session.execute('insert into measures(id_assay,id_experiment,time,measures) values(%s,%s,%s,%s)', (id_assay,id_experiment,timeNow,str(measures)))
+    except:
+        print("could not insert measures")
+    else:
+        session.execute('insert into images(id_assay,id_experiment,time,image) values(%s,%s,%s,%s)',(id_assay, id_experiment, timeNow, str(image)))
+

--- a/src/bulmapsaur/main/image_service.py
+++ b/src/bulmapsaur/main/image_service.py
@@ -21,7 +21,7 @@ async def processImage(idTest,idPlant,imageB64):
         app_log.info("Persisting image %s ...", imageName)
         insert(idTest, idPlant, analyze_results, imageB64)
     except:
-        app_log.info("Image %s was notsuccesfully processed ", imageName)
+        app_log.info("Image %s was not succesfully processed ", imageName)
     else:
         app_log.info("Deleting Image %s from disk ", imageName)
         path = os.path.join(os.getcwd(), imageName+".jpg")

--- a/src/bulmapsaur/main/image_service.py
+++ b/src/bulmapsaur/main/image_service.py
@@ -10,17 +10,17 @@ from plantcv_service import analyze
 from cassandra_connector import insert
 
 
-async def processImage(idTest,idPlant,imageB64):
-    app_log.info("Processing image with idTest %s and idPlant %s...",idTest,idPlant)
+async def processImage(idAssay,idExperiment,imageB64):
+    app_log.info("Processing image with idTest %s and idPlant %s...",idAssay,idExperiment)
     img_decoded = base64Decode(imageB64)
     now = datetime.now()
     dt_string = now.strftime("%d-%m-%Y-%H-%M-%S")
-    imageName = idTest+"-"+idPlant+"-"+dt_string
+    imageName = idAssay+"-"+idExperiment+"-"+dt_string
     saveImage(imageName,img_decoded)
     try:
         analyze_results = analyze(os.path.realpath(imageName + ".jpg"))
         app_log.info("Persisting image %s ...", imageName)
-        insert(idTest, idPlant, analyze_results, imageB64)
+        insert(idAssay, idExperiment, analyze_results, imageB64)
     except:
         app_log.info("Image %s was not succesfully processed ", imageName)
     else:

--- a/src/bulmapsaur/main/image_service.py
+++ b/src/bulmapsaur/main/image_service.py
@@ -11,7 +11,7 @@ from cassandra_connector import insert
 
 
 async def processImage(idAssay,idExperiment,imageB64):
-    app_log.info("Processing image with idTest %s and idPlant %s...",idAssay,idExperiment)
+    app_log.info("Processing image with idAssay %s and idExperiment %s...",idAssay,idExperiment)
     img_decoded = base64Decode(imageB64)
     now = datetime.now()
     dt_string = now.strftime("%d-%m-%Y-%H-%M-%S")

--- a/src/bulmapsaur/main/image_service.py
+++ b/src/bulmapsaur/main/image_service.py
@@ -2,7 +2,8 @@ from tornado.log import app_log
 from utils.encode_utils import base64Decode
 from utils.file_utils import saveImage
 from datetime import datetime
-import os
+import os,time
+
 
 #from image_analyzer import analyze
 from plantcv_service import analyze


### PR DESCRIPTION
Se pushea primero las medidas dado que es mas importante que la imagen , y la imagen al ser un archivo grande puede ser propenso a error y no terminara insertando las medidas.

Ademas se ejecuta asincronamente la inserción de imágenes a cassandra dado que es una consulta que tarda un poco mas y por el catcheo en image_service aveces termina detectando que fallo cuando el realidad logro insertarse exitosamente 